### PR TITLE
add support to graceful shutdown

### DIFF
--- a/cmd/command-handler/main.go
+++ b/cmd/command-handler/main.go
@@ -39,5 +39,5 @@ func main() {
 
 	// Starting gateway http API
 	api := http.NewApi(log, accountsHandler, entriesHandler)
-	api.Start("0.0.0.0", cfg.API.Port)
+	api.Start("0.0.0.0", cfg.API)
 }

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -22,7 +22,8 @@ func LoadConfig() (*Config, error) {
 }
 
 type APIConfig struct {
-	Port string `envconfig:"API_PORT" default:"3000"`
+	Port            string `envconfig:"API_PORT" default:"3000"`
+	ShutdownTimeout string `envconfig:"API_SHUTDOWN_TIMEOUT" default:"5s"`
 }
 
 type PostgresConfig struct {

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -22,8 +23,8 @@ func LoadConfig() (*Config, error) {
 }
 
 type APIConfig struct {
-	Port            string `envconfig:"API_PORT" default:"3000"`
-	ShutdownTimeout string `envconfig:"API_SHUTDOWN_TIMEOUT" default:"5s"`
+	Port            string        `envconfig:"API_PORT" default:"3000"`
+	ShutdownTimeout time.Duration `envconfig:"API_SHUTDOWN_TIMEOUT" default:"5s"`
 }
 
 type PostgresConfig struct {

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -1,8 +1,14 @@
 package http
 
 import (
+	"context"
 	"fmt"
+	"github.com/stone-co/the-amazing-ledger/pkg/common/configuration"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -29,7 +35,7 @@ func NewApi(log *logrus.Logger, accounts *accounts.Handler, entries *entries.Han
 	}
 }
 
-func (a *Api) Start(host, port string) {
+func (a *Api) Start(host string, cfg configuration.APIConfig) {
 	// Router
 	r := mux.NewRouter()
 
@@ -46,16 +52,51 @@ func (a *Api) Start(host, port string) {
 	n := negroni.New(negroni.NewRecovery(), negroni.NewLogger())
 	n.UseHandler(r)
 
-	endpoint := fmt.Sprintf("%s:%s", host, port)
+	endpoint := fmt.Sprintf("%s:%s", host, cfg.Port)
+
+	// Make a channel to listen for an interrupt or terminate signal from the OS.
+	// Use a buffered channel because the signal package requires it.
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	srv := &http.Server{
 		Handler: n,
 		Addr:    endpoint,
 	}
 
-	a.log.Infof("starting API at %s", endpoint)
+	// Make a channel to listen for errors coming from the listener. Use a
+	// buffered channel so the goroutine can exit if we don't collect this error.
+	serverErrors := make(chan error, 1)
 
-	if err := srv.ListenAndServe(); err != nil {
-		a.log.Fatalf("can't run server: %s", err.Error())
+	// Start the service listening for requests.
+	go func() {
+		a.log.Infof("starting API at %s", endpoint)
+		serverErrors <- srv.ListenAndServe()
+	}()
+
+	// =========================================================================
+	// Shutdown
+
+	// Blocking main and waiting for shutdown.
+	select {
+	case err := <-serverErrors:
+		a.log.WithError(err).Fatal("server error")
+
+	case sig := <-shutdown:
+		a.log.Printf("%v : Start shutdown", sig)
+		timeout, err := time.ParseDuration(cfg.ShutdownTimeout)
+		if err != nil {
+			a.log.Warnf("error parsing duration %q. fallbacking to 5 seconds\n", cfg.ShutdownTimeout)
+			timeout = 5 * time.Second
+		}
+		// Give outstanding requests a deadline for completion.
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		// Asking listener to shutdown and shed load.
+		if err := srv.Shutdown(ctx); err != nil {
+			_ = srv.Close()
+			a.log.WithError(err).Fatal("could not stop server gracefully")
+		}
 	}
 }

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -3,6 +3,11 @@ package http
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -11,10 +16,6 @@ import (
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/entries"
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/healthcheck"
 	"github.com/urfave/negroni"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 type Api struct {

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"fmt"
-	"github.com/stone-co/the-amazing-ledger/pkg/common/configuration"
 	"net/http"
 	"os"
 	"os/signal"
@@ -13,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+	"github.com/stone-co/the-amazing-ledger/pkg/common/configuration"
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/accounts"
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/entries"
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/healthcheck"

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -3,12 +3,6 @@ package http
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -17,6 +11,10 @@ import (
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/entries"
 	"github.com/stone-co/the-amazing-ledger/pkg/gateways/http/healthcheck"
 	"github.com/urfave/negroni"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 type Api struct {
@@ -84,13 +82,8 @@ func (a *Api) Start(host string, cfg configuration.APIConfig) {
 
 	case sig := <-shutdown:
 		a.log.Printf("%v : Start shutdown", sig)
-		timeout, err := time.ParseDuration(cfg.ShutdownTimeout)
-		if err != nil {
-			a.log.Warnf("error parsing duration %q. fallbacking to 5 seconds\n", cfg.ShutdownTimeout)
-			timeout = 5 * time.Second
-		}
 		// Give outstanding requests a deadline for completion.
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 		defer cancel()
 
 		// Asking listener to shutdown and shed load.


### PR DESCRIPTION
The intent of this commit is to add the application an ability to shutdown the http server gracefully.

Notes:
- A new environment configuration `API_SHUTDOWN_TIMEOUT`.
- A fallback to **five** seconds in case of the overridden env var has a invalid duration.

Hope it helps! 🤓 