### PR TITLE
refactor: change account_id type to string

### DIFF
--- a/pkg/command-handler/domain/ledger/entities/cached_accounts.go
+++ b/pkg/command-handler/domain/ledger/entities/cached_accounts.go
@@ -2,8 +2,6 @@ package entities
 
 import (
 	"sync"
-
-	"github.com/google/uuid"
 )
 
 type CachedAccountInfo struct {
@@ -21,7 +19,7 @@ func NewCachedAccounts() *CachedAccounts {
 	}
 }
 
-func (c *CachedAccounts) LoadOrStore(accountID uuid.UUID) *CachedAccountInfo {
+func (c *CachedAccounts) LoadOrStore(accountID string) *CachedAccountInfo {
 	object := &CachedAccountInfo{
 		Version: NewAccountVersion,
 	}
@@ -30,7 +28,7 @@ func (c *CachedAccounts) LoadOrStore(accountID uuid.UUID) *CachedAccountInfo {
 	return objectInMap.(*CachedAccountInfo)
 }
 
-func (c *CachedAccounts) Store(accountID uuid.UUID, version Version) {
+func (c *CachedAccounts) Store(accountID string, version Version) {
 	object := &CachedAccountInfo{
 		Version: version,
 	}

--- a/pkg/command-handler/domain/ledger/entities/cached_accounts_test.go
+++ b/pkg/command-handler/domain/ledger/entities/cached_accounts_test.go
@@ -3,7 +3,6 @@ package entities
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,12 +10,12 @@ func TestCachedAccounts_LoadOrStore(t *testing.T) {
 	c := NewCachedAccounts()
 
 	t.Run("New accounts started with version 1", func(t *testing.T) {
-		accountInfo := c.LoadOrStore(uuid.New())
+		accountInfo := c.LoadOrStore("account/123")
 		assert.Equal(t, NewAccountVersion, accountInfo.Version)
 	})
 
 	t.Run("Account info is saved successfully", func(t *testing.T) {
-		accountID := uuid.New()
+		accountID := "account/321/"
 		var version Version = 1234
 		c.Store(accountID, version)
 		accountInfo := c.LoadOrStore(accountID)

--- a/pkg/command-handler/domain/ledger/entities/cached_accounts_test.go
+++ b/pkg/command-handler/domain/ledger/entities/cached_accounts_test.go
@@ -3,19 +3,21 @@ package entities
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCachedAccounts_LoadOrStore(t *testing.T) {
 	c := NewCachedAccounts()
 
+	accountID := uuid.New().String()
+
 	t.Run("New accounts started with version 1", func(t *testing.T) {
-		accountInfo := c.LoadOrStore("account/123")
+		accountInfo := c.LoadOrStore(accountID)
 		assert.Equal(t, NewAccountVersion, accountInfo.Version)
 	})
 
 	t.Run("Account info is saved successfully", func(t *testing.T) {
-		accountID := "account/321/"
 		var version Version = 1234
 		c.Store(accountID, version)
 		accountInfo := c.LoadOrStore(accountID)

--- a/pkg/command-handler/domain/ledger/entities/entry.go
+++ b/pkg/command-handler/domain/ledger/entities/entry.go
@@ -7,12 +7,12 @@ import (
 type Entry struct {
 	ID        uuid.UUID
 	Operation OperationType
-	AccountID uuid.UUID
+	AccountID string
 	Version   Version
 	Amount    int
 }
 
-func NewEntry(id uuid.UUID, operation OperationType, accountID uuid.UUID, version Version, amount int) *Entry {
+func NewEntry(id uuid.UUID, operation OperationType, accountID string, version Version, amount int) *Entry {
 	return &Entry{
 		ID:        id,
 		Operation: operation,

--- a/pkg/command-handler/domain/ledger/entities/transaction_test.go
+++ b/pkg/command-handler/domain/ledger/entities/transaction_test.go
@@ -17,13 +17,13 @@ func TestNewTransaction(t *testing.T) {
 
 	id := uuid.New()
 	validTwoEntries := []Entry{
-		*NewEntry(uuid.New(), DebitOperation, uuid.New(), AnyAccountVersion, 123),
-		*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 123),
+		*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 123),
+		*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
 	}
 	validThreeEntries := []Entry{
-		*NewEntry(uuid.New(), DebitOperation, uuid.New(), AnyAccountVersion, 400),
-		*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 300),
-		*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 100),
+		*NewEntry(uuid.New(), DebitOperation, "account/333", AnyAccountVersion, 400),
+		*NewEntry(uuid.New(), CreditOperation, "account/444", AnyAccountVersion, 300),
+		*NewEntry(uuid.New(), CreditOperation, "account/555", AnyAccountVersion, 100),
 	}
 
 	tests := []struct {
@@ -77,8 +77,8 @@ func TestNewTransaction(t *testing.T) {
 			args: args{
 				id: id,
 				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, uuid.New(), AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 234),
+					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 123),
+					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 234),
 				},
 			},
 			want:        nil,
@@ -89,9 +89,9 @@ func TestNewTransaction(t *testing.T) {
 			args: args{
 				id: id,
 				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, uuid.New(), AnyAccountVersion, 400),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 200),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 100),
+					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 400),
+					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 200),
+					*NewEntry(uuid.New(), CreditOperation, "account/333", AnyAccountVersion, 100),
 				},
 			},
 			want:        nil,
@@ -110,8 +110,8 @@ func TestNewTransaction(t *testing.T) {
 			args: args{
 				id: id,
 				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, uuid.New(), AnyAccountVersion, 0),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 0),
+					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 0),
+					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 0),
 				},
 			},
 			want:        nil,
@@ -122,8 +122,8 @@ func TestNewTransaction(t *testing.T) {
 			args: args{
 				id: id,
 				entries: []Entry{
-					*NewEntry(uuid.New(), InvalidOperation, uuid.New(), AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 123),
+					*NewEntry(uuid.New(), InvalidOperation, "account/111", AnyAccountVersion, 123),
+					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
 				},
 			},
 			want:        nil,
@@ -134,8 +134,8 @@ func TestNewTransaction(t *testing.T) {
 			args: args{
 				id: id,
 				entries: []Entry{
-					*NewEntry(uuid.New(), InvalidOperation, uuid.New(), AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, uuid.New(), AnyAccountVersion, 123),
+					*NewEntry(uuid.New(), InvalidOperation, "account/111", AnyAccountVersion, 123),
+					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
 				},
 			},
 			want:        nil,

--- a/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
+++ b/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
@@ -13,9 +13,12 @@ import (
 )
 
 func TestLedgerUseCase_CreateTransaction(t *testing.T) {
+	accountID1 := uuid.New().String()
+	accountID2 := uuid.New().String()
+
 	t.Run("Successfully creates a transaction with minimum inputs", func(t *testing.T) {
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, "account/111", entities.AnyAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, "account/222", entities.AnyAccountVersion, 123)
+		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.AnyAccountVersion, 123)
+		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.AnyAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := newFakeUseCase(nil).CreateTransaction(context.Background(), uuid.New(), entries)
@@ -24,8 +27,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("Successfully creates a transaction with new accounts", func(t *testing.T) {
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -38,8 +39,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Successfully creates a transaction with expected version", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -59,8 +58,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Fail with invalid expected version", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -80,8 +77,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("When transaction fail, the counter isn't incremented", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -106,8 +101,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
 		lastVersion := useCase.GetLastVersion()
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -143,8 +136,6 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Object version does not change when the idempotency fails, but global counter is changed", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := "account/111"
-		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}

--- a/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
+++ b/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Successfully creates a transaction with minimum inputs", func(t *testing.T) {
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, uuid.New(), entities.AnyAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, uuid.New(), entities.AnyAccountVersion, 123)
+		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, "account/111", entities.AnyAccountVersion, 123)
+		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, "account/222", entities.AnyAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := newFakeUseCase(nil).CreateTransaction(context.Background(), uuid.New(), entries)
@@ -24,8 +24,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("Successfully creates a transaction with new accounts", func(t *testing.T) {
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -38,8 +38,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Successfully creates a transaction with expected version", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -59,8 +59,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Fail with invalid expected version", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -80,8 +80,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("When transaction fail, the counter isn't incremented", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -106,8 +106,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
 		lastVersion := useCase.GetLastVersion()
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
@@ -143,8 +143,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Object version does not change when the idempotency fails, but global counter is changed", func(t *testing.T) {
 		useCase := newFakeUseCase(nil)
 
-		accountID1 := uuid.New()
-		accountID2 := uuid.New()
+		accountID1 := "account/111"
+		accountID2 := "account/222"
 		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
 		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}

--- a/pkg/gateways/db/postgres/migrations/000001_initialize_schema.up.sql
+++ b/pkg/gateways/db/postgres/migrations/000001_initialize_schema.up.sql
@@ -25,7 +25,7 @@ CREATE TYPE operation_type AS ENUM (
 
 CREATE TABLE entries (
 	id             UUID primary key,
-	account_id     UUID not null,
+	account_id     TEXT not null,
 	operation      OPERATION_TYPE not null,
 	amount         INT not null,
 	version        BIGINT not null,

--- a/pkg/gateways/http/transactions/create.go
+++ b/pkg/gateways/http/transactions/create.go
@@ -14,7 +14,7 @@ type CreateTransactionRequest struct {
 	Entries []struct {
 		ID        uuid.UUID `json:"id"`
 		Operation string    `json:"operation"`
-		AccountID uuid.UUID `json:"account_id"`
+		AccountID string    `json:"account_id"`
 		Version   uint64    `json:"version"`
 		Amount    int       `json:"amount"`
 	} `json:"entries"`


### PR DESCRIPTION
Use string instead of uuid.

A Account Id can be "type/system/account/123e4567-e89b-12d3-a456-426614174000" not only uuid "123e4567-e89b-12d3-a456-426614174000" 