### PR TITLE
Feat/validate structure accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ A Web API is used to issue commands and query for data in the ledger.
 curl -i -X POST localhost:3000/transactions -d \
 '{"id":"28c547fa-4dd4-2593-945c-495678d7a123", "entries":[{"id":
 "16b23084-686b-434a-8323-db483ce1e584", "operation":"debit",
-"account_id":"16b23084-686b-434a-8323-db483ce1e589", "version": 0, "amount":
+"account_id":"liability:clients:available:16b23084-686b-434a-8323-db483ce1e589", "version": 0, "amount":
 123},{"id": "16b23084-686b-434a-8323-db483ce1e586", "operation":"credit",
-"account_id":"16b23084-686b-434a-8323-db483ce1e581", "version": 0, "amount":
+"account_id":"liability:clients:available:16b23084-686b-434a-8323-db483ce1e581", "version": 0, "amount":
 123}]}'
 ```

--- a/clients/grpc/examples/invalid_transactions.go
+++ b/clients/grpc/examples/invalid_transactions.go
@@ -23,8 +23,8 @@ func transactionWithInvalidIdReturnsInvalidData(log *logrus.Entry, conn *ledger.
 	invalidUUID := uuid.Nil
 	t := conn.NewTransaction(invalidUUID)
 
-	accountID1 := uuid.New().String()
-	accountID2 := uuid.New().String()
+	accountID1 := "liability:clients:available:" + uuid.New().String()
+	accountID2 := "liability:clients:available:" + uuid.New().String()
 
 	t.AddEntry(uuid.New(), accountID1, entities.NewAccountVersion, entities.DebitOperation, 15000)
 	t.AddEntry(uuid.New(), accountID2, entities.NewAccountVersion, entities.CreditOperation, 15000)
@@ -39,8 +39,8 @@ func entryWithInvalidIdReturnsInvalidData(log *logrus.Entry, conn *ledger.Connec
 
 	t := conn.NewTransaction(uuid.New())
 
-	accountID1 := uuid.New().String()
-	accountID2 := uuid.New().String()
+	accountID1 := "liability:clients:available:" + uuid.New().String()
+	accountID2 := "liability:clients:available:" + uuid.New().String()
 
 	invalidUUID := uuid.Nil
 	t.AddEntry(uuid.New(), accountID1, entities.NewAccountVersion, entities.DebitOperation, 15000)

--- a/clients/grpc/examples/transaction_with_three_entries.go
+++ b/clients/grpc/examples/transaction_with_three_entries.go
@@ -17,9 +17,9 @@ func defineTransactionWithThreeEntries(log *logrus.Entry, conn *ledger.Connectio
 	// Define a new transaction with 3 entries
 	t := conn.NewTransaction(uuid.New())
 
-	accountID1 := uuid.New().String()
-	accountID2 := uuid.New().String()
-	accountID3 := uuid.New().String()
+	accountID1 := "liability:clients:available:" + uuid.New().String()
+	accountID2 := "liability:clients:available:" + uuid.New().String()
+	accountID3 := "liability:clients:available:" + uuid.New().String()
 
 	t.AddEntry(uuid.New(), accountID1, entities.NewAccountVersion, entities.DebitOperation, 15000)
 	t.AddEntry(uuid.New(), accountID2, entities.NewAccountVersion, entities.CreditOperation, 10000)

--- a/cmd/command-handler/main.go
+++ b/cmd/command-handler/main.go
@@ -27,7 +27,7 @@ func main() {
 	defer conn.Close()
 
 	if err = postgres.RunMigrations(cfg.Postgres.URL()); err != nil {
-		log.WithError(err).Fatal("error running postgres migrations")
+		log.WithError(err).Fatal("running postgres migrations")
 	}
 
 	ledgerRepository := postgres.NewLedgerRepository(conn, log)

--- a/pkg/command-handler/domain/ledger/entities/account_name.go
+++ b/pkg/command-handler/domain/ledger/entities/account_name.go
@@ -1,0 +1,41 @@
+package entities
+
+import "strings"
+
+var (
+	classTypes = "|liability|assets|income|expense|equity|"
+)
+
+// AccountName contains exactly 4 levels in her structure: "class:group:subgroup:id", where:
+//   - class could be liability, assets, income, expense or equity;
+//   - group, subgroup and id are "free text".
+//
+// ":" must be used as the separator.
+type AccountName struct { // TODO: could be just "Account", but already exists the type "Account"
+	name string
+}
+
+func NewAccountName(name string) (*AccountName, error) {
+	name = strings.ToLower(name)
+
+	levels := strings.Split(name, ":")
+	if len(levels) < 4 {
+		return nil, ErrInvalidAccountStructure
+	}
+
+	for _, v := range levels {
+		if len(v) == 0 {
+			return nil, ErrInvalidAccountStructure
+		}
+	}
+
+	if !strings.Contains(classTypes, levels[0]) {
+		return nil, ErrInvalidAccountStructure
+	}
+
+	return &AccountName{name}, nil
+}
+
+func (a AccountName) Name() string {
+	return a.name
+}

--- a/pkg/command-handler/domain/ledger/entities/account_name.go
+++ b/pkg/command-handler/domain/ledger/entities/account_name.go
@@ -9,7 +9,7 @@ var (
 	classTypeLevel = 0
 )
 
-// AccountName contains exactly 4 levels in her structure: "class:group:subgroup:id", where:
+// AccountName must contain at least 4 levels in her structure: "class:group:subgroup:id", where:
 //   - class could be liability, assets, income, expense or equity;
 //   - group, subgroup and id are "free text".
 //

--- a/pkg/command-handler/domain/ledger/entities/account_name.go
+++ b/pkg/command-handler/domain/ledger/entities/account_name.go
@@ -3,7 +3,10 @@ package entities
 import "strings"
 
 var (
-	classTypes = "|liability|assets|income|expense|equity|"
+	classTypes     = "|liability|assets|income|expense|equity|"
+	structureSep   = ":"
+	minLevels      = 4
+	classTypeLevel = 0
 )
 
 // AccountName contains exactly 4 levels in her structure: "class:group:subgroup:id", where:
@@ -18,8 +21,8 @@ type AccountName struct { // TODO: could be just "Account", but already exists t
 func NewAccountName(name string) (*AccountName, error) {
 	name = strings.ToLower(name)
 
-	levels := strings.Split(name, ":")
-	if len(levels) < 4 {
+	levels := strings.Split(name, structureSep)
+	if len(levels) < minLevels {
 		return nil, ErrInvalidAccountStructure
 	}
 
@@ -29,7 +32,7 @@ func NewAccountName(name string) (*AccountName, error) {
 		}
 	}
 
-	if !strings.Contains(classTypes, levels[0]) {
+	if !strings.Contains(classTypes, levels[classTypeLevel]) {
 		return nil, ErrInvalidAccountStructure
 	}
 

--- a/pkg/command-handler/domain/ledger/entities/account_name_test.go
+++ b/pkg/command-handler/domain/ledger/entities/account_name_test.go
@@ -1,0 +1,100 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAccountName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "Successfully creates an account name with minimum inputs",
+			args: args{
+				name: "assets:bacen:conta_liquidacao:tesouraria",
+			},
+			err: nil,
+		},
+		{
+			name: "Successfully creates an account name with more than 4 leves",
+			args: args{
+				name: "liability:clients:available:" + uuid.New().String() + ":detail",
+			},
+			err: nil,
+		},
+		{
+			name: "Error when account has only 1 level",
+			args: args{
+				name: "assets",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account has only 2 leves",
+			args: args{
+				name: "assets:bacen",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account has only 3 levels",
+			args: args{
+				name: "assets:bacen:conta_liquidacao",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account omits level 1",
+			args: args{
+				name: ":bacen:conta_liquidacao:tesouraria",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account omits level 2",
+			args: args{
+				name: "assets::conta_liquidacao:tesouraria",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account omits level 3",
+			args: args{
+				name: "assets:bacen::tesouraria",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when account omits level 4",
+			args: args{
+				name: "assets:bacen:conta_liquidacao:",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when level 1 is not one of the predefined values (assets, liability, ...)",
+			args: args{
+				name: "xpto:bacen:conta_liquidacao:tesouraria",
+			},
+			err: ErrInvalidAccountStructure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewAccountName(tt.args.name)
+			assert.Equal(t, tt.err, err)
+			if err == nil {
+				assert.Equal(t, &AccountName{tt.args.name}, got)
+			}
+		})
+	}
+}

--- a/pkg/command-handler/domain/ledger/entities/entry.go
+++ b/pkg/command-handler/domain/ledger/entities/entry.go
@@ -7,17 +7,35 @@ import (
 type Entry struct {
 	ID        uuid.UUID
 	Operation OperationType
-	AccountID string
+	Account   *AccountName
 	Version   Version
 	Amount    int
 }
 
-func NewEntry(id uuid.UUID, operation OperationType, accountID string, version Version, amount int) *Entry {
+func NewEntry(id uuid.UUID, operation OperationType, accountID string, version Version, amount int) (*Entry, error) {
+
+	if id == uuid.Nil {
+		return nil, ErrInvalidData
+	}
+
+	if operation != CreditOperation && operation != DebitOperation {
+		return nil, ErrInvalidData
+	}
+
+	if amount <= 0 {
+		return nil, ErrInvalidData
+	}
+
+	acc, err := NewAccountName(accountID)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Entry{
 		ID:        id,
 		Operation: operation,
-		AccountID: accountID,
+		Account:   acc,
 		Version:   version,
 		Amount:    amount,
-	}
+	}, nil
 }

--- a/pkg/command-handler/domain/ledger/entities/entry.go
+++ b/pkg/command-handler/domain/ledger/entities/entry.go
@@ -13,7 +13,6 @@ type Entry struct {
 }
 
 func NewEntry(id uuid.UUID, operation OperationType, accountID string, version Version, amount int) (*Entry, error) {
-
 	if id == uuid.Nil {
 		return nil, ErrInvalidData
 	}

--- a/pkg/command-handler/domain/ledger/entities/entry_test.go
+++ b/pkg/command-handler/domain/ledger/entities/entry_test.go
@@ -1,0 +1,57 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEntry(t *testing.T) {
+	newUUID := uuid.New()
+
+	t.Run("Successfully creates an entry with minimum inputs", func(t *testing.T) {
+		acc, err := NewAccountName("assets:bacen:conta_liquidacao:tesouraria")
+		assert.Nil(t, err)
+		expected := &Entry{
+			ID:        newUUID,
+			Operation: CreditOperation,
+			Account:   acc,
+			Version:   AnyAccountVersion,
+			Amount:    123,
+		}
+		entry, err := NewEntry(newUUID, CreditOperation, "assets:bacen:conta_liquidacao:tesouraria", AnyAccountVersion, 123)
+		assert.Equal(t, expected, entry)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Invalid when entry id is invalid", func(t *testing.T) {
+		entry, err := NewEntry(uuid.Nil, CreditOperation, "assets:bacen:conta_liquidacao:tesouraria", AnyAccountVersion, 123)
+		assert.Nil(t, entry)
+		assert.Equal(t, ErrInvalidData, err)
+	})
+
+	t.Run("Invalid when operation is invalid", func(t *testing.T) {
+		entry, err := NewEntry(newUUID, InvalidOperation, "assets:bacen:conta_liquidacao:tesouraria", AnyAccountVersion, 123)
+		assert.Nil(t, entry)
+		assert.Equal(t, ErrInvalidData, err)
+	})
+
+	t.Run("Invalid when amount is zero", func(t *testing.T) {
+		entry, err := NewEntry(newUUID, CreditOperation, "assets:bacen:conta_liquidacao:tesouraria", AnyAccountVersion, 0)
+		assert.Nil(t, entry)
+		assert.Equal(t, ErrInvalidData, err)
+	})
+
+	t.Run("Invalid when amount < zero", func(t *testing.T) {
+		entry, err := NewEntry(newUUID, CreditOperation, "assets:bacen:conta_liquidacao:tesouraria", AnyAccountVersion, -1)
+		assert.Nil(t, entry)
+		assert.Equal(t, ErrInvalidData, err)
+	})
+
+	t.Run("Invalid when account structure has less than 4 levels", func(t *testing.T) {
+		entry, err := NewEntry(newUUID, CreditOperation, "assets:bacen:conta_liquidacao", AnyAccountVersion, 123)
+		assert.Nil(t, entry)
+		assert.Equal(t, ErrInvalidAccountStructure, err)
+	})
+}

--- a/pkg/command-handler/domain/ledger/entities/errors.go
+++ b/pkg/command-handler/domain/ledger/entities/errors.go
@@ -3,9 +3,10 @@ package entities
 import "errors"
 
 var (
-	ErrInvalidData          = errors.New("invalid data")
-	ErrInvalidEntriesNumber = errors.New("invalid entries number")
-	ErrInvalidBalance       = errors.New("invalid balance")
-	ErrIdempotencyKey       = errors.New("idempotency key violation")
-	ErrInvalidVersion       = errors.New("invalid version")
+	ErrInvalidData             = errors.New("invalid data")
+	ErrInvalidEntriesNumber    = errors.New("invalid entries number")
+	ErrInvalidBalance          = errors.New("invalid balance")
+	ErrIdempotencyKey          = errors.New("idempotency key violation")
+	ErrInvalidVersion          = errors.New("invalid version")
+	ErrInvalidAccountStructure = errors.New("invalid account structure")
 )

--- a/pkg/command-handler/domain/ledger/entities/transaction.go
+++ b/pkg/command-handler/domain/ledger/entities/transaction.go
@@ -6,7 +6,7 @@ import (
 
 type Transaction struct {
 	ID      uuid.UUID
-	Entries []Entry
+	Entries []Entry // TODO: pointer?
 }
 
 func NewTransaction(id uuid.UUID, entries ...Entry) (*Transaction, error) {
@@ -20,18 +20,6 @@ func NewTransaction(id uuid.UUID, entries ...Entry) (*Transaction, error) {
 
 	balance := 0
 	for _, entry := range entries {
-		if entry.ID == uuid.Nil {
-			return nil, ErrInvalidData
-		}
-
-		if entry.Amount <= 0 {
-			return nil, ErrInvalidData
-		}
-
-		if entry.Operation == InvalidOperation {
-			return nil, ErrInvalidData
-		}
-
 		if entry.Operation == DebitOperation {
 			balance += entry.Amount
 		} else {

--- a/pkg/command-handler/domain/ledger/entities/transaction.go
+++ b/pkg/command-handler/domain/ledger/entities/transaction.go
@@ -6,7 +6,7 @@ import (
 
 type Transaction struct {
 	ID      uuid.UUID
-	Entries []Entry // TODO: pointer?
+	Entries []Entry
 }
 
 func NewTransaction(id uuid.UUID, entries ...Entry) (*Transaction, error) {

--- a/pkg/command-handler/domain/ledger/entities/transaction_test.go
+++ b/pkg/command-handler/domain/ledger/entities/transaction_test.go
@@ -1,7 +1,6 @@
 package entities
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/uuid"
@@ -10,145 +9,67 @@ import (
 )
 
 func TestNewTransaction(t *testing.T) {
-	type args struct {
-		id      uuid.UUID
-		entries []Entry
-	}
-
 	id := uuid.New()
-	validTwoEntries := []Entry{
-		*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 123),
-		*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
-	}
-	validThreeEntries := []Entry{
-		*NewEntry(uuid.New(), DebitOperation, "account/333", AnyAccountVersion, 400),
-		*NewEntry(uuid.New(), CreditOperation, "account/444", AnyAccountVersion, 300),
-		*NewEntry(uuid.New(), CreditOperation, "account/555", AnyAccountVersion, 100),
-	}
 
-	tests := []struct {
-		name        string
-		args        args
-		want        *Transaction
-		expectedErr error
-	}{
-		{
-			name: "Invalid entries number when the transaction has no entries",
-			args: args{
-				id: id,
-			},
-			want:        nil,
-			expectedErr: ErrInvalidEntriesNumber,
-		},
-		{
-			name: "Invalid entries number when the transaction has 1 entry",
-			args: args{
-				id: id,
-			},
-			want:        nil,
-			expectedErr: ErrInvalidEntriesNumber,
-		},
-		{
-			name: "Valid transaction with 2 entries",
-			args: args{
-				id:      id,
-				entries: validTwoEntries,
-			},
-			want: &Transaction{
-				ID:      id,
-				Entries: validTwoEntries,
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "Valid transaction with 3 entries",
-			args: args{
-				id:      id,
-				entries: validThreeEntries,
-			},
-			want: &Transaction{
-				ID:      id,
-				Entries: validThreeEntries,
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "Invalid transaction with 2 entries and balance != 0",
-			args: args{
-				id: id,
-				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 234),
-				},
-			},
-			want:        nil,
-			expectedErr: ErrInvalidBalance,
-		},
-		{
-			name: "Invalid transaction with 3 entries and balance != 0",
-			args: args{
-				id: id,
-				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 400),
-					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 200),
-					*NewEntry(uuid.New(), CreditOperation, "account/333", AnyAccountVersion, 100),
-				},
-			},
-			want:        nil,
-			expectedErr: ErrInvalidBalance,
-		},
-		{
-			name: "Invalid transaction with empty ID",
-			args: args{
-				entries: validTwoEntries,
-			},
-			want:        nil,
-			expectedErr: ErrInvalidData,
-		},
-		{
-			name: "Amount must be > 1",
-			args: args{
-				id: id,
-				entries: []Entry{
-					*NewEntry(uuid.New(), DebitOperation, "account/111", AnyAccountVersion, 0),
-					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 0),
-				},
-			},
-			want:        nil,
-			expectedErr: ErrInvalidData,
-		},
-		{
-			name: "Creating a transaction with an invalid operation must fail",
-			args: args{
-				id: id,
-				entries: []Entry{
-					*NewEntry(uuid.New(), InvalidOperation, "account/111", AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
-				},
-			},
-			want:        nil,
-			expectedErr: ErrInvalidData,
-		},
-		{
-			name: "Creating a transaction with an invalid operation must fail",
-			args: args{
-				id: id,
-				entries: []Entry{
-					*NewEntry(uuid.New(), InvalidOperation, "account/111", AnyAccountVersion, 123),
-					*NewEntry(uuid.New(), CreditOperation, "account/222", AnyAccountVersion, 123),
-				},
-			},
-			want:        nil,
-			expectedErr: ErrInvalidData,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewTransaction(tt.args.id, tt.args.entries...)
-			assert.True(t, errors.Is(err, tt.expectedErr))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewTransaction() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	e11, _ := NewEntry(uuid.New(), DebitOperation, "liability:clients:available:111", AnyAccountVersion, 123)
+	e12, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:222", AnyAccountVersion, 123)
+	validTwoEntries := []Entry{*e11, *e12}
+
+	e21, _ := NewEntry(uuid.New(), DebitOperation, "liability:clients:available:333", AnyAccountVersion, 400)
+	e22, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:444", AnyAccountVersion, 300)
+	e23, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:555", AnyAccountVersion, 100)
+	validThreeEntries := []Entry{*e21, *e22, *e23}
+
+	t.Run("Invalid entries number when the transaction has no entries", func(t *testing.T) {
+		got, err := NewTransaction(id)
+		assert.True(t, errors.Is(err, ErrInvalidEntriesNumber))
+		assert.Nil(t, got)
+	})
+
+	t.Run("Invalid entries number when the transaction has 1 entry", func(t *testing.T) {
+		got, err := NewTransaction(id, *e11)
+		assert.True(t, errors.Is(err, ErrInvalidEntriesNumber))
+		assert.Nil(t, got)
+	})
+
+	t.Run("Valid transaction with 2 entries", func(t *testing.T) {
+		got, err := NewTransaction(id, validTwoEntries...)
+		assert.Nil(t, err)
+		assert.Equal(t, &Transaction{
+			ID:      id,
+			Entries: validTwoEntries,
+		}, got)
+	})
+
+	t.Run("Valid transaction with 3 entries", func(t *testing.T) {
+		got, err := NewTransaction(id, validThreeEntries...)
+		assert.Nil(t, err)
+		assert.Equal(t, &Transaction{
+			ID:      id,
+			Entries: validThreeEntries,
+		}, got)
+	})
+
+	t.Run("Invalid transaction with 2 entries and balance != 0", func(t *testing.T) {
+		e1, _ := NewEntry(uuid.New(), DebitOperation, "liability:clients:available:111", AnyAccountVersion, 123)
+		e2, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:222", AnyAccountVersion, 234)
+		got, err := NewTransaction(id, *e1, *e2)
+		assert.True(t, errors.Is(err, ErrInvalidBalance))
+		assert.Nil(t, got)
+	})
+
+	t.Run("Invalid transaction with 3 entries and balance != 0", func(t *testing.T) {
+		e1, _ := NewEntry(uuid.New(), DebitOperation, "liability:clients:available:111", AnyAccountVersion, 400)
+		e2, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:222", AnyAccountVersion, 200)
+		e3, _ := NewEntry(uuid.New(), CreditOperation, "liability:clients:available:333", AnyAccountVersion, 100)
+		got, err := NewTransaction(id, *e1, *e2, *e3)
+		assert.True(t, errors.Is(err, ErrInvalidBalance))
+		assert.Nil(t, got)
+	})
+
+	t.Run("Invalid transaction with empty ID", func(t *testing.T) {
+		got, err := NewTransaction(uuid.Nil, validTwoEntries...)
+		assert.True(t, errors.Is(err, ErrInvalidData))
+		assert.Nil(t, got)
+	})
 }

--- a/pkg/command-handler/domain/ledger/usecase/create_transaction.go
+++ b/pkg/command-handler/domain/ledger/usecase/create_transaction.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stone-co/the-amazing-ledger/pkg/command-handler/domain/ledger/entities"
 )
 
+// TODO: entries ...Entry?
 func (l *LedgerUseCase) CreateTransaction(ctx context.Context, id uuid.UUID, entries []entities.Entry) error {
 	transaction, err := entities.NewTransaction(id, entries...)
 	if err != nil {
@@ -16,7 +17,7 @@ func (l *LedgerUseCase) CreateTransaction(ctx context.Context, id uuid.UUID, ent
 	accounts := make([]*entities.CachedAccountInfo, 0, len(entries))
 
 	for _, entry := range entries {
-		account := l.cachedAccounts.LoadOrStore(entry.AccountID)
+		account := l.cachedAccounts.LoadOrStore(entry.Account.Name())
 		accounts = append(accounts, account)
 
 		account.Lock()

--- a/pkg/command-handler/domain/ledger/usecase/create_transaction.go
+++ b/pkg/command-handler/domain/ledger/usecase/create_transaction.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stone-co/the-amazing-ledger/pkg/command-handler/domain/ledger/entities"
 )
 
-// TODO: entries ...Entry?
 func (l *LedgerUseCase) CreateTransaction(ctx context.Context, id uuid.UUID, entries []entities.Entry) error {
 	transaction, err := entities.NewTransaction(id, entries...)
 	if err != nil {

--- a/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
+++ b/pkg/command-handler/domain/ledger/usecase/create_transaction_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestLedgerUseCase_CreateTransaction(t *testing.T) {
-	accountID1 := uuid.New().String()
-	accountID2 := uuid.New().String()
+	accountID1 := "liability:clients:available:" + uuid.New().String()
+	accountID2 := "liability:clients:available:" + uuid.New().String()
 
 	t.Run("Successfully creates a transaction with minimum inputs", func(t *testing.T) {
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.AnyAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.AnyAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.AnyAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.AnyAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := newFakeCreateTransactionUseCase(nil).CreateTransaction(context.Background(), uuid.New(), entries)
@@ -27,8 +27,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("Successfully creates a transaction with new accounts", func(t *testing.T) {
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := newFakeCreateTransactionUseCase(nil).CreateTransaction(context.Background(), uuid.New(), entries)
@@ -39,16 +39,16 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Successfully creates a transaction with expected version", func(t *testing.T) {
 		useCase := newFakeCreateTransactionUseCase(nil)
 
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 
 		assert.Nil(t, err)
 
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
 		entries = []entities.Entry{*e1, *e2}
 
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
@@ -58,16 +58,16 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Fail with invalid expected version", func(t *testing.T) {
 		useCase := newFakeCreateTransactionUseCase(nil)
 
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 
 		assert.Nil(t, err)
 
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 4, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 4, 123)
 		entries = []entities.Entry{*e1, *e2}
 
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
@@ -77,8 +77,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("When transaction fail, the counter isn't incremented", func(t *testing.T) {
 		useCase := newFakeCreateTransactionUseCase(nil)
 
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 
 		err := useCase.CreateTransaction(context.Background(), uuid.New(), entries)
@@ -87,8 +87,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 
 		lastVersion := useCase.GetLastVersion()
 
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 4, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 4, 123)
 		entries = []entities.Entry{*e1, *e2}
 
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
@@ -101,32 +101,32 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 		useCase := newFakeCreateTransactionUseCase(nil)
 
 		lastVersion := useCase.GetLastVersion()
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 		err := useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.Nil(t, err)
 		assert.NotEqual(t, lastVersion, useCase.GetLastVersion())
 
 		lastVersion = useCase.GetLastVersion()
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
 		entries = []entities.Entry{*e1, *e2}
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.Nil(t, err)
 		assert.NotEqual(t, lastVersion, useCase.GetLastVersion())
 
 		lastVersion = useCase.GetLastVersion()
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
 		entries = []entities.Entry{*e1, *e2}
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.True(t, errors.Is(err, entities.ErrInvalidVersion))
 		assert.Equal(t, lastVersion, useCase.GetLastVersion())
 
 		lastVersion = useCase.GetLastVersion()
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 4, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 5, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 4, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 5, 123)
 		entries = []entities.Entry{*e1, *e2}
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.Nil(t, err)
@@ -136,22 +136,22 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 	t.Run("Object version does not change when the idempotency fails, but global counter is changed", func(t *testing.T) {
 		useCase := newFakeCreateTransactionUseCase(nil)
 
-		e1 := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
-		e2 := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
+		e1, _ := entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, entities.NewAccountVersion, 123)
+		e2, _ := entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, entities.NewAccountVersion, 123)
 		entries := []entities.Entry{*e1, *e2}
 		err := useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.Nil(t, err)
 
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 2, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 3, 123)
 		entries = []entities.Entry{*e1, *e2}
 		err = useCase.CreateTransaction(context.Background(), uuid.New(), entries)
 		assert.Nil(t, err)
 
 		lastVersion := useCase.GetLastVersion()
 		idempotencyKey := uuid.New()
-		e1 = entities.NewEntry(idempotencyKey, entities.DebitOperation, accountID1, 4, 123)
-		e2 = entities.NewEntry(idempotencyKey, entities.CreditOperation, accountID2, 5, 123)
+		e1, _ = entities.NewEntry(idempotencyKey, entities.DebitOperation, accountID1, 4, 123)
+		e2, _ = entities.NewEntry(idempotencyKey, entities.CreditOperation, accountID2, 5, 123)
 		entries = []entities.Entry{*e1, *e2}
 		useCase.repository = &ledger.RepositoryMock{
 			OnCreateTransaction: func(context.Context, *entities.Transaction) error {
@@ -162,8 +162,8 @@ func TestLedgerUseCase_CreateTransaction(t *testing.T) {
 		assert.True(t, errors.Is(err, entities.ErrIdempotencyKey))
 		assert.NotEqual(t, lastVersion, useCase.GetLastVersion())
 
-		e1 = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 4, 123)
-		e2 = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 5, 123)
+		e1, _ = entities.NewEntry(uuid.New(), entities.DebitOperation, accountID1, 4, 123)
+		e2, _ = entities.NewEntry(uuid.New(), entities.CreditOperation, accountID2, 5, 123)
 		entries = []entities.Entry{*e1, *e2}
 		useCase.repository = &ledger.RepositoryMock{
 			OnCreateTransaction: func(context.Context, *entities.Transaction) error {

--- a/pkg/gateways/db/postgres/create_transaction.go
+++ b/pkg/gateways/db/postgres/create_transaction.go
@@ -35,7 +35,7 @@ func (r *LedgerRepository) CreateTransaction(ctx context.Context, transaction *e
 		batch.Queue(
 			query,
 			entry.ID,
-			entry.AccountID,
+			entry.Account.Name(),
 			entry.Operation.String(),
 			entry.Amount,
 			entry.Version,

--- a/pkg/gateways/http/accounts/create.go
+++ b/pkg/gateways/http/accounts/create.go
@@ -21,7 +21,7 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := h.UseCase.CreateAccount(input); err != nil {
-		log.WithError(err).Error("error creating account")
+		log.WithError(err).Error("creating account")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
With this PR, every account that exists in a transaction must have a valid structure.

To be considered "valid", account name must contain at least 4 levels in her structure: "class:group:subgroup:id", where:
- class could be liability, assets, income, expense or equity;
- group, subgroup and id are "free text".

":" must be used as the separator.