### PR TITLE
feat: show build time and git hash during startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ REGISTRY ?= stoneopenbank
 TERM=xterm-256color
 CLICOLOR_FORCE=true
 RICHGO_FORCE_COLOR=1
+GIT_COMMIT=$(shell git rev-parse HEAD)
+GIT_BUILD_TIME=$(shell date '+%Y-%m-%d__%I:%M:%S%p')
 
 .PHONY: setup
 setup:
@@ -35,7 +37,9 @@ test:
 .PHONY: compile
 compile: clean
 	@echo "==> Go Building CommandHandler"
-	@env GOOS=${OS} GOARCH=amd64 go build -v -o build/${NAME_COMMAND_HANDLER} ${PKG}/${NAME_COMMAND_HANDLER}
+	@env GOOS=${OS} GOARCH=amd64 go build -v -o build/${NAME_COMMAND_HANDLER} \
+		-ldflags "-X main.BuildGitCommit=$(GIT_COMMIT) -X main.BuildTime=$(GIT_BUILD_TIME)" \
+		${PKG}/${NAME_COMMAND_HANDLER} 
 
 .PHONY: build
 build: compile

--- a/cmd/server/buildInfo.go
+++ b/cmd/server/buildInfo.go
@@ -1,0 +1,6 @@
+package main
+
+var (
+	BuildGitCommit = "undefined"
+	BuildTime      = "undefined"
+)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,7 +19,8 @@ import (
 
 func main() {
 	log := logrus.New()
-	log.Infoln("Starting Ledger process...")
+	log.Infoln("starting ledger process...")
+	log.Infof("build info: time[%s] git_hash[%s]", BuildTime, BuildGitCommit)
 
 	cfg, err := app.LoadConfig()
 	if err != nil {


### PR DESCRIPTION
The idea is to show, during server startup, the build time and the git hash used in the build.

Example:

> INFO[0000] starting ledger process...                   
> INFO[0000] build info: time[2021-01-28__10:47:35] git_hash[5f2b1cf744c4c61f07be2fe509a9accdbbe3c2ba] 
> INFO[0000] starting new relic tracing                    appName=omaha-local
> INFO[0000] application created                           app=omaha-local component=newrelic enabled=true grpc-version=1.33.1 version=3.10.0
...
