### PR TITLE
feat: add regex and length validation

### DIFF
--- a/app/domain/entities/transaction_test.go
+++ b/app/domain/entities/transaction_test.go
@@ -61,9 +61,9 @@ func TestNewTransaction(t *testing.T) {
 	})
 
 	t.Run("Invalid transaction with 3 entries and balance != 0", func(t *testing.T) {
-		e1, _ := NewEntry(uuid.New(), vos.DebitOperation, "liability.clients:available.111", vos.NextAccountVersion, 400)
-		e2, _ := NewEntry(uuid.New(), vos.CreditOperation, "liability.clients:available.222", vos.NextAccountVersion, 200)
-		e3, _ := NewEntry(uuid.New(), vos.CreditOperation, "liability.clients:available.333", vos.NextAccountVersion, 100)
+		e1, _ := NewEntry(uuid.New(), vos.DebitOperation, "liability.clients.available.111", vos.NextAccountVersion, 400)
+		e2, _ := NewEntry(uuid.New(), vos.CreditOperation, "liability.clients.available.222", vos.NextAccountVersion, 200)
+		e3, _ := NewEntry(uuid.New(), vos.CreditOperation, "liability.clients.available.333", vos.NextAccountVersion, 100)
 		got, err := NewTransaction(id, e1, e2, e3)
 		assert.True(t, app.ErrInvalidBalance.Is(err))
 		assert.Empty(t, got)

--- a/app/domain/usecases/create_transaction_test.go
+++ b/app/domain/usecases/create_transaction_test.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,8 +18,8 @@ import (
 const _company = "abc"
 
 func TestLedgerUseCase_CreateTransaction(t *testing.T) {
-	accountID1 := "liability.clients.available." + uuid.New().String()
-	accountID2 := "liability.clients.available." + uuid.New().String()
+	accountID1 := "liability.clients.available." + strings.ReplaceAll(uuid.New().String(), "-", "_")
+	accountID2 := "liability.clients.available." + strings.ReplaceAll(uuid.New().String(), "-", "_")
 
 	t.Run("Successfully creates a transaction with minimum inputs", func(t *testing.T) {
 		e1, _ := entities.NewEntry(uuid.New(), vos.DebitOperation, accountID1, vos.NextAccountVersion, 123)

--- a/app/domain/usecases/get_account_balance_test.go
+++ b/app/domain/usecases/get_account_balance_test.go
@@ -15,7 +15,7 @@ func TestLedgerUseCase_GetAccountBalance(t *testing.T) {
 		totalDebit := 130
 		expectedBalance := totalCredit - totalDebit
 
-		account, err := vos.NewAccountPath("liability.stone.clients.user-1")
+		account, err := vos.NewAccountPath("liability.stone.clients.user_1")
 		assert.Nil(t, err)
 
 		accountBalance := vos.NewAccountBalance(account, 3, totalCredit, totalDebit)
@@ -31,7 +31,7 @@ func TestLedgerUseCase_GetAccountBalance(t *testing.T) {
 	t.Run("The max version for account path must be version in account balance", func(t *testing.T) {
 		expectedVersion := vos.Version(5)
 
-		account, err := vos.NewAccountPath("liability.stone.clients.user-1")
+		account, err := vos.NewAccountPath("liability.stone.clients.user_1")
 		assert.Nil(t, err)
 
 		accountBalance := vos.NewAccountBalance(account, expectedVersion, 0, 0)

--- a/app/domain/usecases/get_account_history_test.go
+++ b/app/domain/usecases/get_account_history_test.go
@@ -18,7 +18,7 @@ func TestLedgerUseCase_GetAccountHistory(t *testing.T) {
 	}
 
 	t.Run("The account history can be empty", func(t *testing.T) {
-		account, err := vos.NewAccountPath("liability.stone.clients.user-1")
+		account, err := vos.NewAccountPath("liability.stone.clients.user_1")
 		assert.Nil(t, err)
 
 		entries := []vos.EntryHistory{}
@@ -33,7 +33,7 @@ func TestLedgerUseCase_GetAccountHistory(t *testing.T) {
 	})
 
 	t.Run("The account history should don't modify any Entry History", func(t *testing.T) {
-		account, err := vos.NewAccountPath("liability.stone.clients.user-2")
+		account, err := vos.NewAccountPath("liability.stone.clients.user_2")
 		assert.Nil(t, err)
 
 		entries := make([]vos.EntryHistory, 4)

--- a/app/domain/usecases/get_analytical_data_test.go
+++ b/app/domain/usecases/get_analytical_data_test.go
@@ -33,8 +33,8 @@ func TestLedgerUseCase_GetAnalyticalData(t *testing.T) {
 		query, err := vos.NewAccountQuery("liability.stone.clients")
 		assert.Nil(t, err)
 
-		accountName1 := "liability.stone.clients.user-1"
-		accountName2 := "liability.stone.clients.user-2"
+		accountName1 := "liability.stone.clients.user_1"
+		accountName2 := "liability.stone.clients.user_2"
 
 		entries := []vos.Statement{
 			{

--- a/app/domain/vos/account_path.go
+++ b/app/domain/vos/account_path.go
@@ -1,6 +1,7 @@
 package vos
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/stone-co/the-amazing-ledger/app"
@@ -38,10 +39,14 @@ var _defaultConfig = AccountConfig{
 	DepthSeparator: ".",
 }
 
+var regexOnlyAlphanumericAndUnderscore = regexp.MustCompile(`^[a-zA-Z0-9_]*$`)
+
+const maxLabelLength = 255
+
 // TODO: better docs
 
 // AccountPath can be as deep as needed, limited by AccountConfig MinimumDepth and MaximumDepth.
-// None of the values can be '' (empty string) or '*'.
+// None of the values can be '' (empty string), '*' or more than 255 characters.
 // Depth restrictions can be applied by using DepthConfig. The default configuration for example:
 //	- the first depth is called class
 // 	- it can only be one of the following:
@@ -82,7 +87,11 @@ func NewAccountPath(path string) (AccountPath, error) {
 	}
 
 	for i, component := range components {
-		if component == "" || component == "*" {
+		if component == "" || component == "*" || len(component) > maxLabelLength {
+			return AccountPath{}, app.ErrInvalidAccountStructure
+		}
+
+		if !regexOnlyAlphanumericAndUnderscore.MatchString(component) {
 			return AccountPath{}, app.ErrInvalidAccountStructure
 		}
 

--- a/app/domain/vos/account_path.go
+++ b/app/domain/vos/account_path.go
@@ -46,7 +46,8 @@ const maxLabelLength = 255
 // TODO: better docs
 
 // AccountPath can be as deep as needed, limited by AccountConfig MinimumDepth and MaximumDepth.
-// None of the values can be '' (empty string), '*' or more than 255 characters.
+// None of the values can be '' (empty string), more than 255 characters or characteres other than
+// alphanumeric and underscore (_).
 // Depth restrictions can be applied by using DepthConfig. The default configuration for example:
 //	- the first depth is called class
 // 	- it can only be one of the following:
@@ -87,7 +88,7 @@ func NewAccountPath(path string) (AccountPath, error) {
 	}
 
 	for i, component := range components {
-		if component == "" || component == "*" || len(component) > maxLabelLength {
+		if component == "" || len(component) > maxLabelLength {
 			return AccountPath{}, app.ErrInvalidAccountStructure
 		}
 

--- a/app/domain/vos/account_path_test.go
+++ b/app/domain/vos/account_path_test.go
@@ -1,6 +1,7 @@
 package vos
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestNewAccount(t *testing.T) {
+	id := strings.ReplaceAll(uuid.New().String(), "-", "_")
+
 	type args struct {
 		name string
 	}
@@ -28,21 +31,21 @@ func TestNewAccount(t *testing.T) {
 		{
 			name: "Successfully creates an account name with depth 4",
 			args: args{
-				name: "liability.clients.available." + uuid.New().String(),
+				name: "liability.clients.available." + id,
 			},
 			err: nil,
 		},
 		{
 			name: "Successfully creates an account name with depth 5",
 			args: args{
-				name: "liability.clients.available." + uuid.New().String() + ".mydetail",
+				name: "liability.clients.available." + id + ".mydetail",
 			},
 			err: nil,
 		},
 		{
-			name: "Successfully creates an account name with depth 5",
+			name: "Successfully creates an account name with depth 6",
 			args: args{
-				name: "liability.clients.available." + uuid.New().String() + "/mydetail1/mydetail2/mydetail3",
+				name: "liability.clients.available." + id + ".mydetail1.mydetail2_mydetail3",
 			},
 			err: nil,
 		},
@@ -68,13 +71,6 @@ func TestNewAccount(t *testing.T) {
 			err: app.ErrInvalidAccountStructure,
 		},
 		{
-			name: "Error when account omits level 2",
-			args: args{
-				name: "assets..tesouraria",
-			},
-			err: app.ErrInvalidAccountStructure,
-		},
-		{
 			name: "Error when account omits level 3",
 			args: args{
 				name: "assets.conta_liquidacao.",
@@ -88,12 +84,27 @@ func TestNewAccount(t *testing.T) {
 			},
 			err: app.ErrInvalidAccountStructure,
 		},
+		{
+			name: "Error when account has invalid characters",
+			args: args{
+				name: "assets.conta_liquidacao." + uuid.New().String(),
+			},
+			err: app.ErrInvalidAccountStructure,
+		},
+		{
+			name: "Error when label has more thant 255 characters characters",
+			args: args{
+				name: "assets.bacen.conta_liquidacao." + strings.Repeat("a", maxLabelLength+1),
+			},
+			err: app.ErrInvalidAccountStructure,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewAccountPath(tt.args.name)
-			assert.Equal(t, tt.err, err)
+			assert.ErrorIs(t, err, tt.err)
+
 			if err == nil {
 				assert.Equal(t, tt.args.name, got.Name())
 			}

--- a/app/gateways/rpc/main_test.go
+++ b/app/gateways/rpc/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const ValidTransactionID = "35b2ac20-d733-461c-810a-d7f4acf6316f"
-const ValidAccountID = "liability.clients.available.96a131a8-c4ac-495e-8971-fcecdbdd003a"
+const ValidAccountID = "liability.clients.available.96a131a8_c4ac_495e_8971_fcecdbdd003a"
 
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())


### PR DESCRIPTION
This PR does:
- Add regex validation for labels: must accept only alphanumeric and underscore characters as stated in the documentation (https://www.postgresql.org/docs/13/ltree.html).
-  Add more two scenarios on AccountPath.
- Fix broken tests.