### PR TITLE
feat: added competence date check

### DIFF
--- a/app/gateways/db/postgres/migrations/000004_aggregated_query_balance.up.sql
+++ b/app/gateways/db/postgres/migrations/000004_aggregated_query_balance.up.sql
@@ -21,9 +21,10 @@ select sum(sub.balance) filter (where sub.row_number > 1) as partial_balance,
        max(created_at) filter (where sub.row_number = 2)  as partial_date,
        sum(sub.balance) filter (where sub.row_number = 1) as recent_balance
 from (
-         select coalesce(sum(amount) filter (where operation = 1), 0) - coalesce(sum(amount) filter (where operation = 2), 0) as balance,
+         select coalesce(sum(amount) filter (where operation = 1), 0) -
+                coalesce(sum(amount) filter (where operation = 2), 0) as balance,
                 created_at,
-                row_number() over (order by created_at desc)                                        as row_number
+                row_number() over (order by created_at desc)          as row_number
          from entry
          where account ~ _query
          group by created_at
@@ -47,9 +48,10 @@ select sum(sub.balance) filter (where sub.row_number > 1) as partial_balance,
        max(created_at) filter (where sub.row_number = 2)  as partial_date,
        sum(sub.balance) filter (where sub.row_number = 1) as recent_credit
 from (
-         select coalesce(sum(amount) filter (where operation = 1), 0) - coalesce(sum(amount) filter (where operation = 2), 0) as balance,
+         select coalesce(sum(amount) filter (where operation = 1), 0) -
+                coalesce(sum(amount) filter (where operation = 2), 0) as balance,
                 created_at,
-                row_number() over (order by created_at desc)                                        as row_number
+                row_number() over (order by created_at desc)          as row_number
          from entry
          where account ~ _query
            and created_at > _dt

--- a/app/gateways/rpc/transactions.go
+++ b/app/gateways/rpc/transactions.go
@@ -55,8 +55,8 @@ func (a *API) CreateTransaction(ctx context.Context, req *proto.CreateTransactio
 		domainEntries[i] = domainEntry
 	}
 
-	competenceDate := time.Unix(req.CompetenceDate.Seconds, 0)
-	if competenceDate.After(time.Now()) {
+	competenceDate := time.Unix(req.CompetenceDate.Seconds, 0).UTC()
+	if competenceDate.After(time.Now().UTC()) {
 		return nil, status.Error(codes.InvalidArgument, "competence date set to the future")
 	}
 


### PR DESCRIPTION
Competence date can never be in the future, we should only register events that have happened (or are happening). A way to try to workaround distributed clocks is to set the `competenceDate` precision to seconds.