### PR TITLE
removed Is function implmentation that generates an loop when checkin…

### DIFF
--- a/app/errors.go
+++ b/app/errors.go
@@ -1,7 +1,5 @@
 package app
 
-import "errors"
-
 const (
 	ErrInvalidTransactionID              = DomainError("invalid transaction id")
 	ErrInvalidEntryID                    = DomainError("invalid entry id")
@@ -22,8 +20,4 @@ type DomainError string
 
 func (err DomainError) Error() string {
 	return string(err)
-}
-
-func (err DomainError) Is(target error) bool {
-	return errors.Is(err, target)
 }


### PR DESCRIPTION
When compared errors where different I was getting an infinite loop and stack overflow.
The errors.go was implementing the Is function that was calling Is again.