### PR TITLE
feat: add QueryBuilder struct to encapsulate query related methods

### DIFF
--- a/app/gateways/db/postgres/create_transaction.go
+++ b/app/gateways/db/postgres/create_transaction.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stone-co/the-amazing-ledger/app"
 	"github.com/stone-co/the-amazing-ledger/app/domain/entities"
-	"github.com/stone-co/the-amazing-ledger/app/gateways/db/querybuilder"
 	"github.com/stone-co/the-amazing-ledger/app/shared/instrumentation/newrelic"
 )
 
@@ -18,8 +17,6 @@ const (
 	numDefaultQueries = 5
 )
 
-var queryBuilder querybuilder.QueryBuilder
-
 const createTransactionQuery = `
 insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
 values %s;`
@@ -27,7 +24,7 @@ values %s;`
 func (r LedgerRepository) CreateTransaction(ctx context.Context, transaction entities.Transaction) error {
 	const operation = "Repository.CreateTransaction"
 
-	query := queryBuilder.Build(len(transaction.Entries))
+	query := r.qb.Build(len(transaction.Entries))
 	args := make([]interface{}, 0)
 
 	for _, entry := range transaction.Entries {

--- a/app/gateways/db/postgres/create_transaction.go
+++ b/app/gateways/db/postgres/create_transaction.go
@@ -3,34 +3,31 @@ package postgres
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 
 	"github.com/stone-co/the-amazing-ledger/app"
 	"github.com/stone-co/the-amazing-ledger/app/domain/entities"
+	"github.com/stone-co/the-amazing-ledger/app/gateways/db/querybuilder"
 	"github.com/stone-co/the-amazing-ledger/app/shared/instrumentation/newrelic"
 )
 
 const (
-	queryArgsLength   = 10
-	maxQueriesDefault = 5
+	numArgs           = 10
+	numDefaultQueries = 5
 )
+
+var queryBuilder querybuilder.QueryBuilder
 
 const createTransactionQuery = `
 insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
 values %s;`
 
-var createTransactionQueryMap map[int]string
-
 func (r LedgerRepository) CreateTransaction(ctx context.Context, transaction entities.Transaction) error {
 	const operation = "Repository.CreateTransaction"
 
-	query := getQuery(len(transaction.Entries))
-
+	query := queryBuilder.Build(len(transaction.Entries))
 	args := make([]interface{}, 0)
 
 	for _, entry := range transaction.Entries {
@@ -70,43 +67,4 @@ func (r LedgerRepository) CreateTransaction(ctx context.Context, transaction ent
 	}
 
 	return nil
-}
-
-func getQuery(entriesSize int) string {
-	query, ok := createTransactionQueryMap[entriesSize]
-	if ok {
-		return query
-	}
-
-	query = buildQuery(entriesSize)
-	createTransactionQueryMap[entriesSize] = query
-
-	return query
-}
-
-func buildQuery(entriesSize int) string {
-	var sb strings.Builder
-
-	for i := 0; i < entriesSize; i++ {
-		n := i * queryArgsLength
-
-		sb.WriteString("(")
-
-		for j := 0; j < queryArgsLength; j++ {
-			sb.WriteString("$")
-			sb.WriteString(strconv.Itoa(n + j + 1))
-
-			if j != queryArgsLength-1 {
-				sb.WriteString(", ")
-			}
-		}
-
-		if i != entriesSize-1 {
-			sb.WriteString("),\n")
-		}
-	}
-
-	sb.WriteString(")")
-
-	return fmt.Sprintf(createTransactionQuery, sb.String())
 }

--- a/app/gateways/db/postgres/create_transaction_test.go
+++ b/app/gateways/db/postgres/create_transaction_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -255,60 +254,4 @@ func assertMetadata(t *testing.T, ctx context.Context, db *pgxpool.Pool, id uuid
 	require.NoError(t, err)
 
 	assert.Equal(t, string(want), string(metadata))
-}
-
-func Test_buildQuery(t *testing.T) {
-	testCases := []struct {
-		name     string
-		size     int
-		expected string
-	}{
-		{
-			name: "should create query with 2 entries successfully",
-			size: 2,
-			expected: `
-				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
-				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
-				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20);`,
-		},
-		{
-			name: "should create query with 3 entries successfully",
-			size: 3,
-			expected: `
-				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
-				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
-				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
-				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30);`,
-		},
-		{
-			name: "should create query with 4 entries successfully",
-			size: 4,
-			expected: `
-				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
-				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
-				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
-				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30),
-				($31, $32, $33, $34, $35, $36, $37, $38, $39, $40);`,
-		},
-		{
-			name: "should create query with 5 entries successfully",
-			size: 5,
-			expected: `
-				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
-				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
-				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
-				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30),
-				($31, $32, $33, $34, $35, $36, $37, $38, $39, $40),
-				($41, $42, $43, $44, $45, $46, $47, $48, $49, $50);`,
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildQuery(tt.size)
-			want := strings.ReplaceAll(tt.expected, "\t", "")
-
-			assert.Equal(t, want, got)
-		})
-	}
 }

--- a/app/gateways/db/postgres/ledger.go
+++ b/app/gateways/db/postgres/ledger.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/stone-co/the-amazing-ledger/app/domain"
+	"github.com/stone-co/the-amazing-ledger/app/gateways/db/querybuilder"
 )
 
 const (
@@ -19,18 +20,11 @@ type LedgerRepository struct {
 }
 
 func NewLedgerRepository(db *pgxpool.Pool, log *logrus.Logger) *LedgerRepository {
-	initCreateTransactioQueryMap()
+	queryBuilder = querybuilder.New(createTransactionQuery, numArgs)
+	queryBuilder.Init(numDefaultQueries)
 
 	return &LedgerRepository{
 		db:  db,
 		log: log,
-	}
-}
-
-func initCreateTransactioQueryMap() {
-	createTransactionQueryMap = make(map[int]string)
-
-	for i := 2; i < maxQueriesDefault; i++ {
-		createTransactionQueryMap[i] = buildQuery(i)
 	}
 }

--- a/app/gateways/db/postgres/ledger.go
+++ b/app/gateways/db/postgres/ledger.go
@@ -17,14 +17,16 @@ var _ domain.Repository = &LedgerRepository{}
 type LedgerRepository struct {
 	db  *pgxpool.Pool
 	log *logrus.Logger
+	qb  querybuilder.QueryBuilder
 }
 
 func NewLedgerRepository(db *pgxpool.Pool, log *logrus.Logger) *LedgerRepository {
-	queryBuilder = querybuilder.New(createTransactionQuery, numArgs)
-	queryBuilder.Init(numDefaultQueries)
+	qb := querybuilder.New(createTransactionQuery, numArgs)
+	qb.Init(numDefaultQueries)
 
 	return &LedgerRepository{
 		db:  db,
 		log: log,
+		qb:  qb,
 	}
 }

--- a/app/gateways/db/querybuilder/query_builder.go
+++ b/app/gateways/db/querybuilder/query_builder.go
@@ -1,0 +1,85 @@
+package querybuilder
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type QueryBuilder struct {
+	queries map[int]string
+	query   string
+	numArgs int
+}
+
+func New(query string, numArgs int) QueryBuilder {
+	qb := QueryBuilder{}
+	qb.queries = make(map[int]string)
+	qb.query = query
+	qb.numArgs = numArgs
+
+	return qb
+}
+
+func (q QueryBuilder) Init(numDefaultQueries int) {
+	var offset = 2
+
+	for i := offset; i < numDefaultQueries+offset; i++ {
+		q.queries[i] = q.build(i)
+	}
+}
+
+func (q QueryBuilder) Build(size int) string {
+	query, ok := q.queries[size]
+	if ok {
+		return query
+	}
+
+	return q.build(size)
+}
+
+func (q QueryBuilder) build(size int) string {
+	var sb strings.Builder
+
+	sb.Grow(q.growLength(size))
+
+	for i := 0; i < size; i++ {
+		n := i * q.numArgs
+
+		sb.WriteString("(")
+
+		for j := 0; j < q.numArgs; j++ {
+			sb.WriteString("$")
+			sb.WriteString(strconv.Itoa(n + j + 1))
+
+			if j != q.numArgs-1 {
+				sb.WriteString(", ")
+			}
+		}
+
+		if i != size-1 {
+			sb.WriteString("),\n")
+		}
+	}
+
+	sb.WriteString(")")
+
+	query := fmt.Sprintf(q.query, sb.String())
+	q.queries[size] = query
+
+	return query
+}
+
+func (q QueryBuilder) growLength(size int) int {
+	digitsLength := q.numArgs * 3
+	numberOfDollars := q.numArgs
+	numberOfCommasAndSpaces := (q.numArgs - 1) * 2
+	numberOfParenthesis := 2
+
+	// valuesLength is the length of a value to be inserted ($1, ..., $2)
+	valuesLength := digitsLength + numberOfDollars + numberOfCommasAndSpaces + numberOfParenthesis
+
+	queryLength := len(q.query) + valuesLength*size + (size - 1) + (size-1)*2 - 2
+
+	return queryLength
+}

--- a/app/gateways/db/querybuilder/query_builder.go
+++ b/app/gateways/db/querybuilder/query_builder.go
@@ -6,12 +6,16 @@ import (
 	"strings"
 )
 
+// QueryBuilder builds an insert query based on the number of arguments, how many values to insert,
+// and an initial query defined as `insert into table_name(arg1, ..., argn) values %s;`.
+// QueryBuilder maintains a map of queries that have already been built in memory to improve performance.
 type QueryBuilder struct {
 	queries map[int]string
 	query   string
 	numArgs int
 }
 
+// New creates a QueryBuilder and initializes it with the initial query, the number of arguments, and a 0-size queries map.
 func New(query string, numArgs int) QueryBuilder {
 	qb := QueryBuilder{}
 	qb.queries = make(map[int]string)
@@ -21,14 +25,16 @@ func New(query string, numArgs int) QueryBuilder {
 	return qb
 }
 
-func (q QueryBuilder) Init(numDefaultQueries int) {
+// Init initializes the queries map with n default queries.
+func (q QueryBuilder) Init(n int) {
 	var offset = 2
 
-	for i := offset; i < numDefaultQueries+offset; i++ {
+	for i := offset; i < n+offset; i++ {
 		q.queries[i] = q.build(i)
 	}
 }
 
+// Build builds a query based on the number of values to insert.
 func (q QueryBuilder) Build(size int) string {
 	query, ok := q.queries[size]
 	if ok {

--- a/app/gateways/db/querybuilder/query_builder_test.go
+++ b/app/gateways/db/querybuilder/query_builder_test.go
@@ -1,0 +1,129 @@
+package querybuilder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	qb := New(query, numArgs)
+
+	assert.Len(t, qb.queries, 0)
+	assert.Equal(t, qb.query, query)
+	assert.Equal(t, qb.numArgs, numArgs)
+}
+
+func TestQueryBuilder_Init(t *testing.T) {
+	testCases := []struct {
+		name              string
+		numDefaultQueries int
+		expectedLen       int
+	}{
+		{
+			name:              "should create query builder with 1 default query",
+			numDefaultQueries: 1,
+			expectedLen:       1,
+		},
+		{
+			name:              "should create query builder with 2 default queries",
+			numDefaultQueries: 2,
+			expectedLen:       2,
+		},
+		{
+			name:              "should create query builder with 3 default queries",
+			numDefaultQueries: 3,
+			expectedLen:       3,
+		},
+		{
+			name:              "should create query builder with 4 default queries",
+			numDefaultQueries: 4,
+			expectedLen:       4,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := New(query, numArgs)
+			qb.Init(tt.numDefaultQueries)
+			assert.Len(t, qb.queries, tt.expectedLen)
+		})
+	}
+}
+
+func TestQueryBuilder_Build(t *testing.T) {
+	t.Run("should return a query if not cached successfully", func(t *testing.T) {
+		qb := New(query, numArgs)
+		assert.Len(t, qb.queries, 0)
+
+		qb.Build(2)
+		assert.Len(t, qb.queries, 1)
+	})
+
+	t.Run("should return a query if it's cached successfully", func(t *testing.T) {
+		qb := New(query, numArgs)
+		qb.Init(1)
+		assert.Len(t, qb.queries, 1)
+
+		qb.Build(2)
+		assert.Len(t, qb.queries, 1)
+	})
+}
+
+func TestQueryBuilder_build(t *testing.T) {
+	testCases := []struct {
+		name     string
+		size     int
+		expected string
+	}{
+		{
+			name: "should create query with 2 entries successfully",
+			size: 2,
+			expected: `
+				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
+				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
+				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20);`,
+		},
+		{
+			name: "should create query with 3 entries successfully",
+			size: 3,
+			expected: `
+				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
+				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
+				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
+				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30);`,
+		},
+		{
+			name: "should create query with 4 entries successfully",
+			size: 4,
+			expected: `
+				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
+				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
+				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
+				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30),
+				($31, $32, $33, $34, $35, $36, $37, $38, $39, $40);`,
+		},
+		{
+			name: "should create query with 5 entries successfully",
+			size: 5,
+			expected: `
+				insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
+				values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10),
+				($11, $12, $13, $14, $15, $16, $17, $18, $19, $20),
+				($21, $22, $23, $24, $25, $26, $27, $28, $29, $30),
+				($31, $32, $33, $34, $35, $36, $37, $38, $39, $40),
+				($41, $42, $43, $44, $45, $46, $47, $48, $49, $50);`,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := New(query, numArgs)
+			got := qb.build(tt.size)
+			want := strings.ReplaceAll(tt.expected, "\t", "")
+
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/app/gateways/db/querybuilder/setup_test.go
+++ b/app/gateways/db/querybuilder/setup_test.go
@@ -1,0 +1,20 @@
+package querybuilder
+
+import (
+	"os"
+	"testing"
+)
+
+var (
+	numArgs int
+	query   string
+)
+
+func TestMain(m *testing.M) {
+	numArgs = 10
+	query = `
+insert into entry (id, tx_id, event, operation, version, amount, competence_date, account, company, metadata)
+values %s;`
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This PR does:
- Add QueryBuilder struct o encapsulate query related methods
- Improve build method using strings.Builder.Grow method to preallocate memory before use
- Add QueryBuilder method tests